### PR TITLE
Fix a WordPress deprecation warning

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@ function ebor_cpt_init(){
 
 // Add menu page
 function ebor_cpt_add_options_page() {
-	add_utility_page('Ebor CPT Options Page', 'Ebor CPT', 'manage_options', __FILE__, 'ebor_cpt_render_form');
+	add_menu_page('Ebor CPT Options Page', 'Ebor CPT', 'manage_options', __FILE__, 'ebor_cpt_render_form');
 }
 
 $theme_name = wp_get_theme();


### PR DESCRIPTION
> Notice: add_utility_page вече не трябва да се използва след версия 4.5.0! Заменена е от add_menu_page(). in /Users/dimitar/projects/openmedia/openmedia.bg/web/wp/wp-includes/functions.php on line 3829